### PR TITLE
resolve issue #67: add a line to load item.lisp

### DIFF
--- a/kons-9.asd
+++ b/kons-9.asd
@@ -34,6 +34,7 @@
      (:file "src/kernel/procedural")
      (:file "src/kernel/motion")
      (:file "src/kernel/animator")
+     (:file "src/kernel/item")
      (:file "src/kernel/scene")
      (:file "src/kernel/scene-draw")
      (:file "src/kernel/scene-generics")


### PR DESCRIPTION
kons-9.asd omitted item.lisp from the load, causing a forward-referenced-class error. I added it to the :components form in the asd, which seems to have resolved the eror.