### PR TITLE
Added shell.nix: Nix development environment definition

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,24 @@
+{ pkgs ? (import <nixpkgs> {}) }:
+
+# Define a lisp distribution with all the libraries that we depend on
+# (including their foreign dependencies e.g. OpenGL libraries.)
+let lisp = pkgs.lispPackages_new.sbclWithPackages (p:
+      with p; [ closer-mop
+                trivial-main-thread
+                trivial-backtrace
+                cffi
+                cl-opengl
+                cl-glu
+                cl-glfw3
+              ]); in
+
+# Define a development environment that auto-starts this Lisp.
+pkgs.mkShell {
+  nativeBuildInputs = [ lisp ];
+  shellHook = ''
+    # Start SBCL ready to run:
+    #   (require :kons-9)
+    exec sbcl --eval "(require 'asdf)" --load "kons-9.asd"
+    # (comment line above to get a bash shell with this sbcl in path.)
+  '';
+}


### PR DESCRIPTION
Hey I whipped this up as a convenient way to install kons-9's dependencies on my Linux machine using [Nix](https://nixos.org/nix/). Is this interesting for anyone else? (If it should be merged then what is the appropriate way to document it?)

I use it by running `C-u M-x slime` in the `kons-9` directory and specifying `nix-shell` as the inferior lisp program.

### Commit message:

Add shell.nix such that running:

    kons-9$ nix-shell

will start an SBCL that is ready to run:

    (require :kons-9)

Depends on the Nix package manager to download Lisp library dependencies and their foreign library dependencies (e.g. libglfw.)