### PR TITLE
Embryonic Vulkan backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+*.fasl
 .DS_Store

--- a/kons-9.asd
+++ b/kons-9.asd
@@ -14,7 +14,8 @@
      #:cffi
      #:cl-opengl
      #:cl-glu
-     #:cl-glfw3) 
+     #:cl-glfw3
+     #:cl-vulkan)
     :serial t
     :components
     ((:file "src/package")

--- a/kons-9.asd
+++ b/kons-9.asd
@@ -26,6 +26,7 @@
      (:file "src/kernel/noise")
      (:file "src/graphics/opengl/opengl")
      (:file "src/graphics/opengl/ui")
+     (:file "src/graphics/vulkan/vulkan")
 ;     (:file "src/graphics/opengl/text")
      (:file "src/kernel/item")
      (:file "src/kernel/transform")

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,24 @@
+{ pkgs ? (import <nixpkgs> {}) }:
+
+# Define a lisp distribution with all the libraries that we depend on
+# (including their foreign dependencies e.g. OpenGL libraries.)
+let lisp = pkgs.lispPackages_new.sbclWithPackages (p:
+      with p; [ closer-mop
+                trivial-main-thread
+                trivial-backtrace
+                cffi
+                cl-opengl
+                cl-glu
+                cl-glfw3
+              ]); in
+
+# Define a development environment that auto-starts this Lisp.
+pkgs.mkShell {
+  nativeBuildInputs = [ lisp ];
+  shellHook = ''
+    # Start SBCL ready to run:
+    #   (require :kons-9)
+    exec sbcl --eval "(require 'asdf)" --load "kons-9.asd"
+    # (comment line above to get a bash shell with this sbcl in path.)
+  '';
+}

--- a/shell.nix
+++ b/shell.nix
@@ -2,23 +2,41 @@
 
 # Define a lisp distribution with all the libraries that we depend on
 # (including their foreign dependencies e.g. OpenGL libraries.)
-let lisp = pkgs.lispPackages_new.sbclWithPackages (p:
-      with p; [ closer-mop
-                trivial-main-thread
-                trivial-backtrace
-                cffi
-                cl-opengl
-                cl-glu
-                cl-glfw3
-              ]); in
+let
+  # sbcl custom initialization
+  sbcl-initrc = pkgs.writeText "sbcl-initrc.lisp"
+  ''
+    ;; CL-OpenGL default behaviour is to make prohibitively expensive
+    ;; calls to mask floating point traps.
+    ;; These are already set globally in kons-9 and redundant.
+    ;; See: https://github.com/3b/cl-opengl#readme
+    (pushnew :cl-opengl-no-masked-traps *features*)
+    (pushnew :cl-opengl-no-check-error *features*)
+  '';
+  # sbcl customized startup script
+  sbcl-script = "${pkgs.sbcl}/bin/sbcl --load ${sbcl-initrc} --script";
+  # sbcl customized distribution with dependencies
+  sbcl = pkgs.lispPackages_new.lispWithPackages sbcl-script (p:
+    with p; [ closer-mop
+              trivial-main-thread
+              trivial-backtrace
+              cffi
+              cl-opengl
+              cl-glu
+              cl-glfw3
+              cl-vulkan
+            ]);
+in
 
 # Define a development environment that auto-starts this Lisp.
 pkgs.mkShell {
-  nativeBuildInputs = [ lisp ];
+  nativeBuildInputs = [ sbcl ];
   shellHook = ''
     # Start SBCL ready to run:
     #   (require :kons-9)
-    exec sbcl --eval "(require 'asdf)" --load "kons-9.asd"
+    exec sbcl --load ${sbcl-initrc} \
+              --eval "(require 'asdf)" \
+              --load "kons-9.asd"
     # (comment line above to get a bash shell with this sbcl in path.)
   '';
 }

--- a/src/graphics/vulkan/vulkan.lisp
+++ b/src/graphics/vulkan/vulkan.lisp
@@ -1,0 +1,31 @@
+(defpackage #:kons-9/vulkan
+  (:use :common-lisp :alexandria
+        :vk :cffi :%vk))
+(in-package #:kons-9/vulkan)
+
+;;; Embryonic vulkan graphics backend for Kons-9.
+
+(defclass kons-9-app (vulkan-application-mixin)
+  ((device :accessor device)
+   (index :accessor queue-family-index)
+   (queue :accessor queue)
+   (command-pool :accessor command-pool)
+   (command-buffers :accessor command-buffers)))
+
+(defun open-window-for-one-second (&optional (app (make-instance 'kons-9-app)))
+  (let* ((device (default-logical-device app))
+         (main-window (main-window app))
+         (index (queue-family-index (render-surface main-window)))
+         (queue (find-queue device index))
+         (command-pool (find-command-pool device index))
+         (command-buffer (elt (command-buffers command-pool) 0)))
+    (device-wait-idle device)
+    (reset-command-pool device command-pool)
+    (begin-command-buffer command-buffer)
+    ;; "one time commands here"
+    (end-command-buffer command-buffer)
+    (queue-submit1 queue command-buffer)
+    (device-wait-idle device)
+    (sleep 1)
+    (shutdown-application app)
+    ))


### PR DESCRIPTION
This branch adds an embryonic Vulkan backend that currently only opens a blank window, waits one second, and then closes it.

> The longest journey begins with a single step.

This serves to (re)open a few questions:

- [ ] Do we want to use Vulkan?
- [ ] Is now the time to start?
- [ ] Is this a reasonable first step?
- [ ] What will be the second step?

Here is my unsolicited opinion on the topic based on no relevant experience whatsoever 😁

1. Yes, we want to use Vulkan. Sure, it will be harder and more complex, but Lisp hackers should not be learning legacy OpenGL APIs now in 2022. Better to bite the bullet and use a modern forwards-looking stack with more opportunities going forward.
2. Yes, now is the time to start using Vulkan. The OpenGL backend does not have the performance for medium-size scenes and it does not make sense to optimize that code (see above.) I for one need ~100K vertices minimum for my first steps to model printed circuit board fragments.
3. Yes, this is a reasonable first step. It basically just pulls in @awolven's CL-VULKAN dependency and checks that it works to "Hello world" level. (Sorry, I need to choose an `ACCEPT` restart during compilation on this branch for some reason.)
4. The next step would be to draw the origin in a Vulkan-idiomatic way. I suppose that would involve line-drawing using three vertex pairs loaded into buffers and then (third step) with a shader for adding the camera perspective... but I don't know if that is accurate?

I would welcome feedback from someone who knows what they are doing :laughing: 