### PR TITLE
Add automatic testing of pull requests using Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: "Test"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v15
+      with:
+        nix_path: nixpkgs=channel:nixos-22.05
+    - run: nix-build shell.nix
+    - run: nix-shell --run "sbcl --script test.lisp"

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,48 @@
+{ pkgs ? (import <nixpkgs> {}) }:
+
+# Define a lisp distribution with all the libraries that we depend on
+# (including their foreign dependencies e.g. OpenGL libraries.)
+let
+  # sbcl custom initialization
+  sbcl-initrc = pkgs.writeText "sbcl-initrc.lisp"
+  ''
+    ;; CL-OpenGL default behaviour is to make prohibitively expensive
+    ;; calls to mask floating point traps.
+    ;; These are already set globally in kons-9 and redundant.
+    ;; See: https://github.com/3b/cl-opengl#readme
+    (pushnew :cl-opengl-no-masked-traps *features*)
+  '';
+  # sbcl customized startup script
+  sbcl-script = "${pkgs.sbcl}/bin/sbcl --load ${sbcl-initrc} --script";
+  # sbcl customized distribution with dependencies
+  sbcl = pkgs.lispPackages_new.lispWithPackages sbcl-script (p:
+    # List of packages to install. Update as needed.  Names are the
+    # same as in Quicklisp (except leading _ if the first character is
+    # numeric e.g. 1am => _1am.)
+    with p; [ closer-mop
+              trivial-main-thread
+              trivial-backtrace
+              cffi
+              cl-opengl
+              cl-glu
+              cl-glfw3
+              origin
+            ]);
+in
+
+# Define a development environment that auto-starts this Lisp.
+pkgs.mkShell {
+  nativeBuildInputs =
+    # Generate 'sbcl' script with all dependencies available and
+    # kons-9.asd loaded.
+    # FIXME: must run in kons-9 top-level directory to find
+    # the kons-9.asd file.
+    [ (pkgs.writeShellScriptBin "sbcl"
+       ''
+         exec ${sbcl}/bin/sbcl --load ${sbcl-initrc} \
+                               --eval "(require 'asdf)" \
+                               --load kons-9.asd \
+                               $@
+       '')
+    ];
+}

--- a/test.lisp
+++ b/test.lisp
@@ -1,0 +1,7 @@
+(require :asdf)
+(load "kons-9.asd")
+(format t "~&~%Loading kons-9~%")
+(asdf:oos 'asdf:load-op :kons-9)
+(format t "~&Testing kons-9~%")
+(asdf:oos 'asdf:test-op :kons-9)
+(format t "~&OK~%")

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sbcl --load "kons-9.asd"

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-sbcl --load "kons-9.asd"


### PR DESCRIPTION
This PR adds automatic pull-request testing using Github Actions.

This should *Just Work* on any branches containing these changes, including this one, and including other peoples' own Github forks.

The test is simple:

```
(asdf:load-op :kons-9)
(asdf:test-op :kons-9)
```

and failure is defined as `sbcl` exiting with non-zero status.

This addresses #112 should be sufficient to catch problems like #110.

On this branch the test environment (sbcl + dependencies) is installed via [Nix](https://nixos.org/). This gives a lot of control over dependencies e.g. ability to pin and patch them. I set this up according to the instructions at https://nix.dev/tutorials/continuous-integration-github-actions

An alternative would be to use e.g. `apt-get install sbcl` and Quicklisp for installation. I am happy to volunteer to maintain the Nix script but I have no objection if someone prefers to rework it in anther way and maintain that.

To run this test manually you can simply install Nix and then (on this branch) run:

```
kons-9$ nix-shell --run "sbcl --script test.lisp"
```

and it will automatically run using exactly the same sbcl and dependencies as the Github action. (I have only tested this on Linux/x86-64 but it might also work on Mac, I would be curious to know.)

See also [`act`](https://github.com/nektos/act) for a universal way of running Github Actions locally.