### PR TITLE
Minor cleanups and portability fixes

### DIFF
--- a/kons-9.asd
+++ b/kons-9.asd
@@ -14,7 +14,9 @@
      #:cffi
      #:cl-opengl
      #:cl-glu
-     #:cl-glfw3) 
+     #:cl-glfw3
+     #:cl-freetype2
+     #:font-discovery) 
     :serial t
     :components
     ((:file "src/package")

--- a/src/graphics/opengl/opengl3-text.lisp
+++ b/src/graphics/opengl/opengl3-text.lisp
@@ -5,13 +5,6 @@
   (pushnew :gl-polygon-mode *features*)
   (pushnew :gl-clip-origin *features*))
 
-(eval-when (:compile-toplevel :load-toplevel)
-  (ql:quickload :cl-freetype2))
-
-(eval-when (:compile-toplevel :load-toplevel)
-  (use-package :ft2))
-
-
 #+NOTYET(declaim (inline clampf))
 (defun clampf (number)
   "Clamp real number to single-float limits."
@@ -371,7 +364,10 @@
   (loop for i from from to to
      collect i))
 
-(defun ensure-font (&optional (pathname #+darwin "/System/Library/Fonts/Monaco.ttf" #+linux "/usr/share/fonts/TTF/DejaVuSansMono.ttf") (size 12))
+(defun default-font ()
+  (org.shirakumo.font-discovery:file (org.shirakumo.font-discovery:find-font :family "DejaVuSansMono")))
+
+(defun ensure-font (&optional (pathname (default-font)) (size 12))
   (let ((last-texture (gl:get-integer :texture-binding-2d)))
     (with-open-face (face pathname)
       (ft2:set-pixel-sizes face 0 (* *framebuffer-scale* size))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,5 +1,5 @@
 (defpackage #:kons-9
-  (:use #:common-lisp)
+  (:use #:common-lisp #:ft2)
   (:export
    #:*scene*
    #:run


### PR DESCRIPTION
Declare dependencies in asdf file
(instead of calling QL:QUICKLOAD)

Declare :USES in DEFPACKAGE
(instead of calling USE-PACKAGE.)

Use FONT-DISCOVERY library to locate .ttf font file (instead of non-portable hardcoded paths.)

These changes were necessary to run in my environment.