### PR TITLE
Moved gl:color-material calls before enables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+.vscode

--- a/src/graphics/opengl/opengl.lisp
+++ b/src/graphics/opengl/opengl.lisp
@@ -347,8 +347,8 @@
          (g (c-green col))
          (b (c-blue col)))
     (gl-set-material col)
+    (gl:color-material :front-and-back :diffuse)
     (with-gl-enable :color-material
-      (gl:color-material :front-and-back :diffuse)
       (cond ((and (> (length point-colors) 0) *do-smooth-shading?*)
              (dotimes (f (length faces))
                (gl:begin :polygon)
@@ -395,8 +395,8 @@
 (defmethod 3d-draw-filled-polygons-aux-SAV (points faces face-normals point-normals point-colors)
   (let ((col (shading-color *drawing-settings*)))
     (gl-set-material col)
+    (gl:color-material :front-and-back :diffuse)
     (with-gl-enable :color-material
-      (gl:color-material :front-and-back :diffuse)
       (dotimes (f (length faces))
         (gl:begin :polygon)
         (when (not *do-smooth-shading?*)
@@ -427,8 +427,8 @@
 
 (defmethod 3d-draw-highlighted-polygons-aux (points faces face-normals point-normals faces-highlighted)
   (let ((sel-col (sel-color *drawing-settings*)))
+    (gl:color-material :front-and-back :diffuse)
     (with-gl-enable :color-material
-      (gl:color-material :front-and-back :diffuse)
       (dotimes (f (length faces))
         (when (aref faces-highlighted f)
           (gl:begin :polygon)


### PR DESCRIPTION
This is as indicated by the spec. Also added a gitignore line for the editor that I use. Fixes #50.

Just to be sure, I also dumped the gl state commands for frames when the bug was happening (before close) and when it wasn't (after reopen) and diffed them, I saw no substantial differences. I would be interested to know why the driver can't deal with this. 

[See the second paragraph of the Notes section of the documentation hosted at docs.gl.](https://docs.gl/gl3/glColorMaterial)