### PR TITLE
Continuous integration with GitHub actions

### DIFF
--- a/.github/workflows/run-testsuite-darwin-big-sur.yaml
+++ b/.github/workflows/run-testsuite-darwin-big-sur.yaml
@@ -1,4 +1,4 @@
-name: 'Run testsuite'
+name: 'Run testsuite on Big Sur'
 on:
   - workflow_dispatch
   - push

--- a/.github/workflows/run-testsuite.yaml
+++ b/.github/workflows/run-testsuite.yaml
@@ -24,8 +24,21 @@ jobs:
           sudo port install sbcl cl-quicklisp glfw
       - name: 'Install Quicklisp in CI environment'
         run: |
-          sbcl --load '/opt/local/share/cl-quicklisp/quicklisp.lisp' --eval '(quicklisp-quickstart:install)' --eval '(ql-util:without-prompting (ql:add-to-init-file))' --quit
+          sbcl\
+            --load '/opt/local/share/cl-quicklisp/quicklisp.lisp'\
+            --eval '(quicklisp-quickstart:install)'\
+            --eval '(ql-util:without-prompting (ql:add-to-init-file))'\
+            --quit
+          printf '\n(pushnew \043p\"%s\" ql:*local-project-directories*)\n' "${GITHUB_WORKSPACE}" >> ~/.sbclrc
+          cat ~/.sbclrc
+      - name: 'Clone Confidence'
+        run: |
+          cd ~/quicklisp/local-projects
+          git clone https://github.com/melusina-org/cl-confidence.git
       - name: 'Checkout repository'
         uses: actions/checkout@v3
+      - name: 'Register Quicklisp local projects'
+        run: |
+          sbcl --eval '(ql:register-local-projects)' --quit
       - name: 'Run the testsuite'
         run: 'development/testsuite'

--- a/.github/workflows/run-testsuite.yaml
+++ b/.github/workflows/run-testsuite.yaml
@@ -1,0 +1,31 @@
+name: 'Run testsuite'
+on:
+  - workflow_dispatch
+  - push
+jobs:
+  run-testsuite:
+    runs-on: 'macos-11'
+    permissions:
+      contents: read
+    steps:
+      - name: 'Download MacPorts'
+        run: |
+         wget https://github.com/macports/macports-base/releases/download/v2.7.1/MacPorts-2.7.1-11-BigSur.pkg
+      - name: 'Install MacPorts'
+        run: |
+          sudo installer -pkg ./MacPorts-2.7.1-11-BigSur.pkg -target /
+      - name: 'Add MacPorts to the PATH'
+        run: |
+          sudo install -o root -g wheel -m 644 /dev/null /etc/paths.d/900-macports
+          sudo sh -c "printf '/opt/local/bin' > /etc/paths.d/900-macports"
+          printf '/opt/local/bin' > "${GITHUB_PATH}"
+      - name: 'Install SBCL and Kons-9 dependencies'
+        run: |
+          sudo port install sbcl cl-quicklisp glfw
+      - name: 'Install Quicklisp in CI environment'
+        run: |
+          sbcl --load '/opt/local/share/cl-quicklisp/quicklisp.lisp' --eval '(quicklisp-quickstart:install)' --eval '(ql-util:without-prompting (ql:add-to-init-file))' --quit
+      - name: 'Checkout repository'
+        uses: actions/checkout@v3
+      - name: 'Run the testsuite'
+        run: 'development/testsuite'

--- a/development/testsuite
+++ b/development/testsuite
@@ -23,6 +23,7 @@ testsuite_run()
 	set -- 'run-all-tests'
     fi
     testsuite_lisp\
+	--eval "(load #p\"${TOPLEVELDIR}/tools/verify-quicklisp.lisp\")"\
 	--eval "(load #p\"${TOPLEVELDIR}/tools/verify-confidence.lisp\")"\
 	--eval "(ql:quickload \"${testsuitesystem}\" :silent t)"\
 	--eval "(${testsuitesystem}:$1)"

--- a/tools/verify-confidence.lisp
+++ b/tools/verify-confidence.lisp
@@ -1,27 +1,46 @@
 #| Doctor for #155 https://github.com/kaveh808/kons-9/issues/155 |#
 (in-package #:cl-user)
 
-(let ((bad-confidence-quicklisp-versions
-	'("cl-confidence-20220707-git"))
-      (current-confidence-quicklisp-verion
-	(first
-	 (last
-	  (pathname-directory
-	   (ql:where-is-system "org.melusina.confidence"))))))
-  (when (member current-confidence-quicklisp-verion
-		bad-confidence-quicklisp-versions
-		:test #'string-equal )
-    (format t "~&Error: Your current version of Confidence from Quicklisp is too old.")
-    (format t "~&~%A temporary solution is to clone an up-to-date version of Confidence
+(defun quicklisp-local-projects ()
+  (car (last ql:*local-project-directories*)))
+
+(defun confidence-is-not-installed ()
+  (format t "~&Error: Confidence is not installed.")
+  (format t "~&~%A solution is to clone Confidence
+in a directory that is examined by Quicklisp. For instance using the following
+shell commands
+
+  cd ~A
+  git clone git@github.com:melusina-org/cl-confidence.git~%"
+	  (quicklisp-local-projects))
+  (quit :unix-status 1))
+
+(defun confidence-is-outdated ()
+  (format t "~&Error: Your current version of Confidence from Quicklisp is too old.")
+  (format t "~&~%A temporary solution is to clone an up-to-date version of Confidence
 in a directory that is examined by Quicklisp. For instance using the following
 shell commands
 
   cd ~A
   git clone git@github.com:melusina-org/cl-confidence.git
 
-The first line needs to be adapted if Quicklisp has been installed in an
-exotic location.
-
 Please visit https://github.com/kaveh808/kons-9/issues/155 to follow
-the discussion about this issue." "~/quicklisp/local-projects")
-    (quit :unix-status 1)))
+the discussion about this issue.~%"  (quicklisp-local-projects))
+  (quit :unix-status 1))
+
+(defun current-confidence-quicklisp-version ()
+  (let ((pathname
+	  (ql:where-is-system "org.melusina.confidence")))
+    (when pathname
+      (car (last (pathname-directory pathname))))))
+
+(let ((bad-confidence-quicklisp-versions
+	'("cl-confidence-20220707-git"))
+      (current-confidence-quicklisp-version
+	(current-confidence-quicklisp-version)))
+  (unless current-confidence-quicklisp-version
+    (confidence-is-not-installed))
+  (when (member current-confidence-quicklisp-version
+		bad-confidence-quicklisp-versions
+		:test #'string-equal )
+    (confidence-is-outdated)))

--- a/tools/verify-quicklisp.lisp
+++ b/tools/verify-quicklisp.lisp
@@ -1,0 +1,13 @@
+#| Doctor for Quicklisp Installation |#
+(in-package #:cl-user)
+
+(defun quicklisp-is-not-installed ()
+  (format t "~&Error: Quicklisp is not installed.")
+  (format t "~&~%A solution is to install Quicklisp by following the instructions found under
+
+  https://www.quicklisp.org/beta/~%")
+  (quit :unix-status 1))
+
+
+(unless (find-package "QUICKLISP-CLIENT")
+  (quicklisp-is-not-installed))


### PR DESCRIPTION
This PR uses GitHub actions to run the test suite on MacOS X Big Sur (Mac Os X 11) on every commit.

Things to improve later:

  - The workflow is rather long, [caching the installation of MacPorts could help](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows) but we could also [create a preloaded runtime](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts) since MacPorts supports the creation of packages.
  -  Running on other environments seems desirable, maybe one environment could be used as a quick test to catch early errors before longer tests are performed.
  - Testing with other Common Lisps, such as ECL.