### PR TITLE
testsuite: Import referenced Confidence symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ Load the system:
 
 List all available tests with
 
-    (kons-9/testsuite:list-all-available-tests)
+    (kons-9/testsuite:list-available-tests)
 
 Tests are implemented as regular functions and can be run with
 statements similar to
 
-    (kons-9/testsuite:run-all-available-tests)
+    (kons-9/testsuite:run-all-tests)
 
 or
 

--- a/testsuite/package.lisp
+++ b/testsuite/package.lisp
@@ -9,7 +9,9 @@
     #:assert-condition
     #:assert-eq
     #:assert-list-equal
-    #:assert-float-is-essentially-equal)
+    #:assert-float-is-essentially-equal
+    #:list-testcases
+    #:*testcase-interactive-p*)
    (:export
     #:list-available-tests
     ))


### PR DESCRIPTION
I'm having three problems with the test suite. This branch seems to fix the first one. (EDIT: Others resolved now too.)

- [x] `KONS-9/TESTSUITE` references Confidence symbols that it doesn't import.
- [x] Test suite functions are exiting the whole Lisp process when called interactively at the REPL.
- [x] Test suite functions mentioned in the README are not defined/exported in `KONS-9/TESTSUITE`.

Maybe a commit got lost somewhere @foretspaisibles? Hope this change & report is of some use.

P.S. It is great to see the test suite code!