### PR TITLE
Add VALIDATE for checking scene item invariants (code-as-documentation)

### DIFF
--- a/kons-9.asd
+++ b/kons-9.asd
@@ -54,6 +54,7 @@
    (:file "src/kernel/scene-duplicate")
    (:file "src/kernel/protocol")
    (:file "src/kernel/clobber")
+   (:file "src/kernel/validate")
    (:file "src/kernel/main")
    ;; font libraries -- tmp until we use 3b-bmfont
    (:module "lib/JMC-font-libs/font-master"

--- a/kons-9.asd
+++ b/kons-9.asd
@@ -112,7 +112,8 @@
 		 (:file "assertions")
  		 (:module "kernel"
  		  :components ((:file "utils")
-			       (:file "point-cloud")))
+			       (:file "point-cloud")
+			       (:file "validation")))
  		 (:file "entrypoint")))))
 
 #+nil (asdf:load-system :kons-9)

--- a/src/kernel/color.lisp
+++ b/src/kernel/color.lisp
@@ -3,7 +3,7 @@
 ;;;; color ==============================================================
 
 (deftype color ()
-  "Mutable vector of R,G,B,A signle-float values between zero and one."
+  "Mutable vector of R,G,B,A single-float values between zero and one."
   '(vector * 4))
 
 (defun color? (x)

--- a/src/kernel/color.lisp
+++ b/src/kernel/color.lisp
@@ -2,6 +2,14 @@
 
 ;;;; color ==============================================================
 
+(deftype color ()
+  "Mutable vector of R,G,B,A signle-float values between zero and one."
+  '(vector * 4))
+
+(defun color? (x)
+  (and (typep x 'color)
+       (every (lambda (x) (typep x '(single-float 0.0f0 1.0f0))) x)))
+
 ;;; we define colors as simple vectors
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defun c! (r g b &optional (a 1.0))

--- a/src/kernel/curve.lisp
+++ b/src/kernel/curve.lisp
@@ -4,7 +4,9 @@
 
 ;;; this shape is defined by an array of points (vertices)
 (defclass curve (point-cloud)
-  ((is-closed-curve? :accessor is-closed-curve? :initarg :is-closed-curve? :initform t)))
+  ((is-closed-curve? :accessor is-closed-curve? :initarg :is-closed-curve? :initform t :type boolean
+                     :documentation "Closed curves implicitly loop from last point back to first point."))
+  (:documentation "A curve is an open or closed (looping) path through a point cloud."))
 
 (defun make-curve (points &optional (is-closed-curve? t))
   (make-instance 'curve :points points :is-closed-curve? is-closed-curve?))

--- a/src/kernel/point-cloud.lisp
+++ b/src/kernel/point-cloud.lisp
@@ -6,8 +6,8 @@
   ((points :accessor points :initarg :points :initform (make-array 0 :adjustable t :fill-pointer t)
            :documentation "Contained points." :type vector)
    (point-colors :accessor point-colors :initarg :point-colors :initform nil
-                 :documentation "Color of each point." :type (or null vector)))
-  (:documentation "A point cloud is an ordered sequence of optionally colored set of points in 3D space."))
+                 :documentation "Color of each point (or null if unspecified.)" :type (or null vector)))
+  (:documentation "A point cloud is a sequence of (optionally colored) points in 3D space."))
 
 (defmethod printable-data ((self point-cloud))
   (strcat (call-next-method) (format nil ", ~a points" (length (points self)))))

--- a/src/kernel/point-cloud.lisp
+++ b/src/kernel/point-cloud.lisp
@@ -3,8 +3,11 @@
 ;;;; point-cloud ========================================================
 
 (defclass point-cloud (shape)
-  ((points :accessor points :initarg :points :initform (make-array 0 :adjustable t :fill-pointer t))
-   (point-colors :accessor point-colors :initarg :point-colors :initform nil)))
+  ((points :accessor points :initarg :points :initform (make-array 0 :adjustable t :fill-pointer t)
+           :documentation "Contained points." :type vector)
+   (point-colors :accessor point-colors :initarg :point-colors :initform nil
+                 :documentation "Color of each point." :type (or null vector)))
+  (:documentation "A point cloud is an ordered sequence of optionally colored set of points in 3D space."))
 
 (defmethod printable-data ((self point-cloud))
   (strcat (call-next-method) (format nil ", ~a points" (length (points self)))))

--- a/src/kernel/point-origin.lisp
+++ b/src/kernel/point-origin.lisp
@@ -8,6 +8,13 @@
   (defun p! (x y z)
     (p:vec (coerce x 'single-float) (coerce y 'single-float) (coerce z 'single-float))))
 
+(deftype point ()
+  "Point in 3D space expressed as a single-float 3-vector."
+  'p:vec)
+
+(defun point? (x)
+  (typep x 'point))
+
 (defun point->list (p)
   (list (p:x p) (p:y p) (p:z p)))
 

--- a/src/kernel/point.lisp
+++ b/src/kernel/point.lisp
@@ -28,13 +28,6 @@
 (defun p! (x y z &optional w)
   (point:new :svec3 x y z w)))
 
-(deftype point ()
-  "Point in 3D space expressed as a single-float 3-vector."
-  'p:vec)
-
-(defun point? (x)
-  (typep x 'point))
-
 ;; (defun point->list (p)
 ;;   (list (x p) (y p) (z p)))
 

--- a/src/kernel/point.lisp
+++ b/src/kernel/point.lisp
@@ -28,6 +28,13 @@
 (defun p! (x y z &optional w)
   (point:new :svec3 x y z w)))
 
+(deftype point ()
+  "Point in 3D space expressed as a single-float 3-vector."
+  'p:vec)
+
+(defun point? (x)
+  (typep x 'point))
+
 ;; (defun point->list (p)
 ;;   (list (x p) (y p) (z p)))
 

--- a/src/kernel/polyhedron.lisp
+++ b/src/kernel/polyhedron.lisp
@@ -3,11 +3,17 @@
 ;;;; polyhedron ================================================================
 
 (defclass polyhedron (point-cloud)
-  ((faces :accessor faces :initarg :faces :initform (make-array 0 :adjustable t :fill-pointer t))
-   (face-normals :accessor face-normals :initarg :face-normals :initform (make-array 0 :adjustable t :fill-pointer t))
-   (point-normals :accessor point-normals :initarg :point-normals :initform (make-array 0 :adjustable t :fill-pointer t))
-   (show-normals :accessor show-normals :initarg :show-normals :initform nil)  ; length or nil
-   (point-source-use-face-centers? :accessor point-source-use-face-centers? :initarg :point-source-use-face-centers? :initform nil)))
+  ((faces :accessor faces :initarg :faces :initform (make-array 0 :adjustable t :fill-pointer t) :type (vector-of :index-list)
+          :documentation "Faces bounding the polyhedron. A face is a set of point indices.")
+   (face-normals :accessor face-normals :initarg :face-normals :initform (make-array 0 :adjustable t :fill-pointer t) :type (vector-of :point-list)
+                 :documentation "Unit normal vector to each corresponding face.")
+   (point-normals :accessor point-normals :initarg :point-normals :initform (make-array 0 :adjustable t :fill-pointer t) :type (vector-of :point-list)
+                  :documentation "Unit normal vector to each corresponding point (vertex.)")
+   (show-normals :accessor show-normals :initarg :show-normals :initform nil :type (or null integer)
+                 :documentation "Scaling factor for showing normals in the UI (or null for do not show.)")
+   (point-source-use-face-centers? :accessor point-source-use-face-centers? :initarg :point-source-use-face-centers? :initform nil :type boolean
+                                   :documentation "Use face centers instead of vertices when used as a point-source."))
+  (:documentation "3D shape bounded by a set of polygonal faces."))
 
 (defmethod printable-data ((self polyhedron))
   (strcat (call-next-method) (format nil ", ~a faces" (length (faces self)))))

--- a/src/kernel/utils.lisp
+++ b/src/kernel/utils.lisp
@@ -182,3 +182,18 @@
 (defun clamp (x lo hi)
   (max lo (min x hi)))
 
+;;;; informal types ============================================================
+
+;; Handy types to reference as documentation but only weakly checked.
+;; Uses of these types could be tightened up later e.g. as element-typed vectors.
+
+(deftype vector-of (informal-element-type)
+  "Vector containing elements of INFORMAL-ELEMENT-TYPE (any value, not checked.)"
+  (declare (ignore informal-element-type))
+  'vector)
+
+(deftype list-of (informal-element-type)
+  "List containing elements of INFORMAL-ELEMENT-TYPE (any value, not checked.)"
+  (declare (ignore informal-element-type))
+  'list)
+

--- a/src/kernel/utils.lisp
+++ b/src/kernel/utils.lisp
@@ -182,6 +182,19 @@
 (defun clamp (x lo hi)
   (max lo (min x hi)))
 
+;; Cribbed from https://rosettacode.org/wiki/Approximate_equality#Common_Lisp
+;; but with default threshold loosened up.
+(defun ~= (float1 float2 &optional (threshold 0.0001))
+  "Determine whether float1 and float2 are equal; THRESHOLD is the
+maximum allowable difference between normalized significands of floats
+with the same exponent. The significands are scaled appropriately
+before comparison for floats with different exponents."
+  (multiple-value-bind (sig1 exp1 sign1) (decode-float float1)
+    (multiple-value-bind (sig2 exp2 sign2) (decode-float float2)
+      (let ((cmp1 (float-sign sign1 (scale-float sig1 (floor (- exp1 exp2) 2))))
+            (cmp2 (float-sign sign2 (scale-float sig2 (floor (- exp2 exp1) 2)))))
+        (< (abs (- cmp1 cmp2)) threshold)))))
+
 ;;;; informal types ============================================================
 
 ;; Handy types to reference as documentation but only weakly checked.

--- a/src/kernel/validate.lisp
+++ b/src/kernel/validate.lisp
@@ -56,7 +56,7 @@
       errors)))
 
 (defun verror (format &rest format-args)
-  "Signal a (continuable) validation error on *VALIDATION-SUBJET*."
+  "Signal a (continuable) validation error on *VALIDATION-SUBJECT*."
   (check-type format string)
   (with-simple-restart (ignore "Ignore this single error and continue.")
     (error (make-instance 'validation-error

--- a/src/kernel/validate.lisp
+++ b/src/kernel/validate.lisp
@@ -1,0 +1,146 @@
+;;;; scene-item validation machinery ===========================================
+;;;
+;;; This file defines the generic function VALIDATE for detecting errors in
+;;; SCENE and SCENE-ITEM objects.
+;;;
+;;; VALIDATE methods serve two purposes:
+;;; - As documentation to say what invariants apply to each kind of object.
+;;; - As a tool for discovering broken invariants and recovering from them.
+;;;
+;;; VALIDATE can be called manually and/or hooked into SCENE-UPDATE via
+;;; *AUTO-VALIDATE-ON-SCENE-UPDATE*.
+
+(in-package #:kons-9)
+
+(defvar *validation-subject* nil
+  "The object being validated by VALIDATE.")
+
+(defvar *validation-aspect* nil
+  "Named aspect of *VALIDATION-SUBJECT* that is being validated.")
+
+(defgeneric validate (scene-or-item)
+  (:documentation "Signal VALIDATION-ERROR if SCENE-OR-TIME is not valid.")
+  ;; Scenes are validated via their constituent items.
+  (:method ((scene scene))
+    (do-children (item (shape-root scene))  (validate item))
+    (do-children (item (motion-root scene)) (validate item)))
+  ;; Scene items are valid by default.
+  (:method ((item scene-item)) t)
+  ;; User-friendly restarts are available while validating scene items.
+  (:method :around ((item scene-item))
+    (with-simple-restart (pass-item "Skip validation of scene item ~a" (name item))
+      (loop (with-simple-restart (revalidate "Retry validation of ~a" (name item))
+              (let ((*validation-subject* item))
+                (return (call-next-method))))))
+    (values)))
+
+(define-condition validation-error (error)
+  ((item :initarg :item)
+   (aspect :initarg :aspect)
+   (format :initarg :format)
+   (args :initarg :args))
+  (:report (lambda (condition stream)
+             (with-slots (item aspect format args) condition
+               (format stream "[~a~@['s ~a~]] ~?" (name item) aspect format args))))
+  (:documentation
+   "Invalid scene-item detected."))
+
+(defun count-validation-errors (scene-item)
+  "Return the total number of errors detected by VALIDATE."
+  (let ((errors 0))
+    (handler-bind ((validation-error (lambda (c)
+                                       (declare (ignore c))
+                                       (incf errors)
+                                       (invoke-restart 'ignore))))
+      (validate scene-item)
+      errors)))
+
+(defun verror (format &rest format-args)
+  "Signal a (continuable) validation error on *VALIDATION-SUBJET*."
+  (check-type format string)
+  (with-simple-restart (ignore "Ignore this single error and continue.")
+    (error (make-instance 'validation-error
+                          :item *validation-subject* :aspect *validation-aspect*
+                          :format format :args format-args))))
+
+(defmacro validating (aspect-name &body body)
+  "Validate ASPECT-NAME of *VALIDATION-SUBJECT* by executing BODY."
+  `(let ((*validation-aspect* ,aspect-name))
+     (with-simple-restart (pass "Skip validating ~a of ~a."
+                                ,aspect-name (name *validation-subject*))
+       ,@body)))
+
+(defmacro vassert (expr &optional fmt &rest fmt-args)
+  "Assert EXPR to validate *VALIDATION-SUBJECT*."
+  `(if ,expr t (verror "Assert ~a failed~@[: ~?~]." ',expr ,fmt ,@fmt-args)))
+
+;;;; point-cloud validation ====================================================
+
+(defmethod validate ((scene scene))
+  (do-children (item (shape-root scene))  (validate item))
+  (do-children (item (motion-root scene)) (validate item)))
+
+;;;; point-cloud validation ====================================================
+
+(defmethod validate ((pc point-cloud))
+  (declare (optimize (debug 3)))
+  (call-next-method)
+  (with-slots (points point-colors) pc
+    (validating :points
+      (when (vassert (vectorp points))
+        (loop for p across points
+              do (unless (point? p)
+                   (verror "Invalid point: ~a" p)))))
+    (when point-colors
+      (validating :point-colors
+        (when (vassert (vectorp point-colors))
+          (vassert (alexandria:length= points point-colors))
+          (loop for c across point-colors
+                do (unless (color? c)
+                     (verror "Invalid color: ~a" c))))))))
+
+;;;; curve validation ==========================================================
+
+(defmethod validate ((cv curve))
+  (declare (optimize (debug 3)))
+  (call-next-method)
+  (with-slots (points) cv
+    (validating :points
+      (vassert (>= (length points) 2) "a curve must have at least two points."))))
+
+;;;; polyhedron validation =====================================================
+
+(defmethod validate ((ph polyhedron))
+  (declare (optimize (debug 3)))
+  (call-next-method)
+  (with-slots (points faces face-normals point-normals) ph
+    ;; XXX Should empty polyhedrons be allowed to pass validation too?
+    (when (vassert (>= (length faces) 3))
+      (validating :faces
+        (when (vassert (vectorp faces))
+          (do-array (f face faces)
+            (dolist (ix face)
+              (let ((max-index (1- (length points))))
+                (unless (and (integerp ix) (<= 0 ix max-index))
+                  (verror "Invalid vertex reference ~a in face ~a" ix f)))))))
+      ;; IDEA: Verify that the sum of the face normals, weighted by the area
+      ;; of that face, is zero. That seems like an interesting invariant.
+      ;; Have to implement FACE-AREA to do this though.
+      (validating :face-normals
+        ;; Normal should be a unit vector.
+        (do-array (fn face-normal face-normals)
+          (~= 1.0 (p:length face-normal))))
+      (validating :point-normals
+        (do-array (pn point-normal point-normals)
+          (~= 1.0 (p:length point-normal)))))))
+
+;;;; Hook to automatically validate scene updates ==============================
+
+(defvar *auto-validate-on-scene-update* nil
+  "Automatically validate the scene before and after each SCENE-UPDATE.")
+
+(defmethod update-scene :around ((scene scene) &optional (num-frames 1))
+  (declare (ignore num-frames))
+  (if *scene-auto-validate*
+      (progn (validate scene) (call-next-method) (validate scene))
+      (call-next-method)))

--- a/testsuite/kernel/validation.lisp
+++ b/testsuite/kernel/validation.lisp
@@ -1,0 +1,68 @@
+(in-package #:kons-9/testsuite)
+
+;; Scene items validate by default.
+(define-testcase validate/valid ()
+  (assert-t* (kons-9::validate (make-instance 'kons-9::scene-item)))
+  (assert-condition (kons-9::validate 42) error))
+
+;;; point cloud ----------------------------------------------------------------
+
+(define-testcase validate/valid ()
+  (loop for item in (valid-scene-items)
+        do (assert-t (progn (kons-9::validate item) t))))
+
+(defun valid-scene-items ()
+  "List of scene items that are expected to validate successfully."
+  ;; Just a few plucked from the demos.
+  (list (make-instance 'kons-9::scene-item)
+        ;; Point clouds (note: many other objects are point-clouds by inheritance too)
+        (make-instance 'kons-9::point-cloud
+                       :points (kons-9::make-line-points (kons-9::p! 0 0 0) (kons-9::p! 1 1 1) 100))
+        (make-instance 'kons-9::point-cloud
+                       :points (kons-9::make-rectangle-points 1 1 10))
+        ;; Curves
+        (kons-9::make-line-curve (kons-9::p! 0 0 0) (kons-9::p! 2 2 2) 8)
+        (kons-9::make-rectangle-curve 2 1 4)
+        (kons-9::make-square-curve 1.5)
+        (kons-9::make-circle-curve 2.0 16)
+        (kons-9::make-arc-curve 2.0 0 90 16)
+        (kons-9::make-sine-curve-curve 360 1 2 1 16)
+        (kons-9::make-spiral-curve .2 2.0 -1.0 4 64)
+        ;; Polyhedrons
+        (kons-9::make-tetrahedron  2.0)
+        (kons-9::make-cube         2.0)
+        (kons-9::make-octahedron   2.0)
+        (kons-9::make-dodecahedron 2.0)
+        (kons-9::make-icosahedron  2.0)))
+
+(define-testcase validate/invalid ()
+  (let ((origin (kons-9::p! 0 0 0))
+        (black #(0.0f0 0.0f0 0.0f0 1.0f0)))
+    (flet ((errors (item)
+             (kons-9::count-validation-errors item)))
+      ;; Safety low so that we can pass wrong-typed initargs to MAKE-INSTANCE.
+      (declare (optimize (safety 0) (speed 0) (debug 3)))
+      ;; point-clouds POINTS must be a vector
+      (assert-eq 1 (errors (make-instance 'kons-9::point-cloud :points ())))
+      ;; ... of points.
+      (assert-eq 3 (errors (make-instance 'kons-9::point-cloud :points (vector black t :foo))))
+
+      ;; point-cloud POINT-COLORS must be a vector
+      (assert-eq 1 (errors (make-instance 'kons-9::point-cloud :points (vector origin) :point-colors :non-list)))
+      ;; ... of the same length as POINTS
+      (assert-eq 1 (errors (make-instance 'kons-9::point-cloud :points (vector origin) :point-colors #())))
+      ;; .. containing colors.
+      (assert-eq 2 (errors (make-instance 'kons-9::point-cloud :points (vector origin origin origin)
+                                                               :point-colors (vector black origin :bar))))
+
+      ;; Curves require at least two points.
+      (assert-eq 1 (errors (make-instance 'kons-9::curve :points #())))
+      (assert-eq 1 (errors (make-instance 'kons-9::curve :points (vector (kons-9::p! 0 0 0)))))
+
+      ;; Polyhedrons aren't valid if empty.
+      (assert-condition (kons-9::validate (make-instance 'kons-9::polyhedron)) kons-9::validation-error)
+
+      ;; Validation doesn't work on objects that aren't scene-items.
+      (assert-condition (validate :non-item) error))))
+
+;;; point cloud ----------------------------------------------------------------

--- a/testsuite/package.lisp
+++ b/testsuite/package.lisp
@@ -10,6 +10,8 @@
     #:assert-eq
     #:assert-list-equal
     #:assert-float-is-essentially-equal
+    #:assert-t
+    #:assert-t*
     #:list-testcases
     #:*testcase-interactive-p*)
    (:export


### PR DESCRIPTION
I've started reading the kons-9 source to understand the data structures. I wanted a way to write notes that are shareable, useful, and maintainable. This branch is what I came up with.

Youtube one-minute summary of the motivation: https://youtu.be/yDfMQ3Q9gFA

Or in code,

- 84662e4 adds one-liner docstrings and types to each slot of POINT-CLOUD, CURVE, and POLYHEDRON. Maybe this information is obvious to some but it wasn't to me!
- 8fd2c00 specifies invariant properties of these same classes in the form of VALIDATE methods. You can use them to check your scenes for corrupt data.
- 3de0f87 exercises VALIDATE in the testsuite with both valid and invalid example scene items.

Whaddayareckon? Is working through the data structures and documenting them this way a useful form of code-as-documentation?

CI should confirm that these tests pass:

```
CL-USER> (kons-9/testsuite::validate/valid)
Name: KONS-9/TESTSUITE:VALIDATE/VALID
Total: 15
Success: 15/15 (100%)
Failure: 0/15 (0%)
Condition: 0/15 (0%)
Outcome: Success
...
CL-USER> (kons-9/testsuite::validate/invalid)
Name: KONS-9/TESTSUITE:VALIDATE/INVALID
Total: 9
Success: 9/9 (100%)
Failure: 0/9 (0%)
Condition: 0/9 (0%)
Outcome: Success
...
```
