### PR TITLE
Track changes in Confidence interface

### DIFF
--- a/development/testsuite
+++ b/development/testsuite
@@ -26,7 +26,8 @@ testsuite_run()
 	--eval "(load #p\"${TOPLEVELDIR}/tools/verify-quicklisp.lisp\")"\
 	--eval "(load #p\"${TOPLEVELDIR}/tools/verify-confidence.lisp\")"\
 	--eval "(ql:quickload \"${testsuitesystem}\" :silent t)"\
-	--eval "(${testsuitesystem}:$1)"
+	--eval "(${testsuitesystem}:$1)"\
+	--eval "(org.melusina.confidence:quit)"
 }
 
 testsuite_main()


### PR DESCRIPTION
A valid case has been made against Confidence behaviour, where Confidence is trying to be smart about quitting the Lisp image when the test suite completes. This is a bad idea, the Lisp image is precious and qui should me made explicit.

See  https://github.com/melusina-org/cl-confidence/issues/5 for a more detailed conversation.

This updates how we run the test suite, especially in GitHub Actions, so that https://github.com/melusina-org/cl-confidence/tree/do-not-quit-automatically fixing  https://github.com/melusina-org/cl-confidence/issues/5 can be merged.

KONS-9 users should not be affected in any way, except that Confidence does not surprisingly exits the image anymore.
