### PR TITLE
Use GitHub Action to install MacPorts

### DIFF
--- a/.github/parameters/gha-install-macports.yaml
+++ b/.github/parameters/gha-install-macports.yaml
@@ -1,0 +1,7 @@
+variants:
+  deselect: x11
+ports:
+  - name: sbcl
+    select: fancy
+  - name: cl-quicklisp
+  - name: glfw

--- a/.github/workflows/run-testsuite-darwin-big-sur.yaml
+++ b/.github/workflows/run-testsuite-darwin-big-sur.yaml
@@ -9,35 +9,25 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: 'Download MacPorts'
-        run: |
-         wget https://github.com/macports/macports-base/releases/download/v2.7.1/MacPorts-2.7.1-11-BigSur.pkg
+      - name: 'Checkout repository'
+        uses: actions/checkout@v3
       - name: 'Install MacPorts'
-        run: |
-          sudo installer -pkg ./MacPorts-2.7.1-11-BigSur.pkg -target /
-      - name: 'Add MacPorts to the PATH'
-        run: |
-          sudo install -o root -g wheel -m 644 /dev/null /etc/paths.d/900-macports
-          sudo sh -c "printf '/opt/local/bin' > /etc/paths.d/900-macports"
-          printf '/opt/local/bin' > "${GITHUB_PATH}"
-      - name: 'Install SBCL and Kons-9 dependencies'
-        run: |
-          sudo port install sbcl cl-quicklisp glfw
+        id: 'macports'
+        uses: melusina-org/gha-install-macports@v1
       - name: 'Install Quicklisp in CI environment'
-        run: |
-          sbcl\
-            --load '/opt/local/share/cl-quicklisp/quicklisp.lisp'\
-            --eval '(quicklisp-quickstart:install)'\
-            --eval '(ql-util:without-prompting (ql:add-to-init-file))'\
-            --quit
+        run: >-
+          sbcl
+          --load '${{ steps.macports.outputs.prefix }}/share/cl-quicklisp/quicklisp.lisp'
+          --eval '(quicklisp-quickstart:install)'
+          --eval '(ql-util:without-prompting (ql:add-to-init-file))'
+          --quit
+      - name: 'Add Workspace to Quicklisp local project directories'
+        run: >-
           printf '\n(pushnew \043p\"%s\" ql:*local-project-directories*)\n' "${GITHUB_WORKSPACE}" >> ~/.sbclrc
-          cat ~/.sbclrc
       - name: 'Clone Confidence'
         run: |
           cd ~/quicklisp/local-projects
           git clone https://github.com/melusina-org/cl-confidence.git
-      - name: 'Checkout repository'
-        uses: actions/checkout@v3
       - name: 'Register Quicklisp local projects'
         run: |
           sbcl --eval '(ql:register-local-projects)' --quit


### PR DESCRIPTION
I wrote a reusable GitHub Action to install MacPorts. Using this in the project will add caching of the MacPorts installation and reduce the duration for the execution of the automated test suite.

Fixes #196