### PR TITLE
Generate HTML API documentation using Github Actions

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -1,0 +1,35 @@
+name: Publish to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-api-docs:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v22
+      - name: Check out
+        uses: actions/checkout@v1
+      - name: Build HTML API documentation with MGL-PAX
+        run: nix --experimental-features "nix-command flakes" build .#api-html
+      - name: Workaround File Permissions # See (https://github.com/actions/deploy-pages/issues/58)
+        run: cp -r -L --no-preserve=mode,ownership result artifact
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'artifact'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,7 @@
       in {
         apps.default = { type = "app"; program = "${run-kons-9}/bin/run-kons-9"; };
         apps.test    = { type = "app"; program = "${test-kons-9}/bin/test-kons-9"; };
+        packages.default  = run-kons-9;
         packages.api-html = api-html;
       }
     );


### PR DESCRIPTION
This PR adds a Github Action to automatically build and publish the (nascent) Kons-9 API documentation (#219) in HTML to Github Pages.

Once merged the URL https://kaveh808.github.io/kons-9 should always contain the latest successfully built docs from the main branch of this repository.

This will also provide some additional test coverage in that the examples in the API documentation are automatically verified and the build will fail if they don't produce the expected results.

Could require some fiddling with Github Actions settings. I can look into that if it doesn't work as expected immediately after merge.

This is working on my kons-9 branch:
- Github Action result: https://github.com/lukego/kons-9/actions/runs/5121959800
- Published page: https://lukego.github.io/kons-9