### PR TITLE
(fix) ray: use appropriate function to instantiate ray

### DIFF
--- a/src/kernel/ray.lisp
+++ b/src/kernel/ray.lisp
@@ -10,14 +10,14 @@
 
 (defun intersect-aabb (ray point-min point-max)
   (origin.geometry:raycast-aabb
-   (origin.geometry.ray:ray :origin (from ray) :direction (to ray))
+   (origin.geometry.ray:ray-from-points :from (from ray) :to (to ray))
    (origin.geometry.aabb:aabb-from-min/max
     :min point-min :max point-max)))
 
 (defun intersect-triangle (ray p0 p1 p2)
   (intersect/triangle
    (origin.geometry.triangle:triangle p0 p1 p2)
-   (origin.geometry.ray:ray :origin (from ray) :direction (to ray))))
+   (origin.geometry.ray:ray-from-points :from (from ray) :to (to ray))))
 
 (defun intersect-triangles (ray triangles)
   (let ((min-distance nil))


### PR DESCRIPTION
This commit fixes ray creation which fixes a bit of unexpected behaviour of object picking. See the `observation` note towards the end of this comment: https://github.com/kaveh808/kons-9/pull/222

The origin library provides a couple of functions to create a ray. Prior to this, we used a helper function which expected the ray `origin` and `direction` as parameters while what was actually being passed were the `from` and `to` coordinates. In this commit we use the more appropriate function which expects the `from` and `to` coordinates.