### PR TITLE
Follow upstream to SETUP-MACPORTS

### DIFF
--- a/.github/workflows/run-testsuite-darwin-big-sur.yaml
+++ b/.github/workflows/run-testsuite-darwin-big-sur.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
       - name: 'Install MacPorts'
         id: 'macports'
-        uses: melusina-org/gha-install-macports@v1
+        uses: melusina-org/setup-macports@v1
       - name: 'Install Quicklisp in CI environment'
         run: >-
           sbcl


### PR DESCRIPTION
I'm about to archive gha-install-macports and continue work in setup-macports, so you might want to use that as well.