### PR TITLE
introduce point picking selection mode for ray and cone

### DIFF
--- a/src/plugins/uv-mesh.lisp
+++ b/src/plugins/uv-mesh.lisp
@@ -202,7 +202,7 @@
           (let ((scaled-point-array (copy-point-array point-array))
                 (s-mtx (make-scale-matrix (p:lerp (p! 1 1 1) (p! taper taper taper) factor)
                                           p1)))
-            (transform-point-array! scaled-point-array s-mtx)		      
+            (transform-point-array! scaled-point-array s-mtx)
             (do-array (u p2 scaled-point-array)
               (setf (aref (uv-point-array mesh) u v) (p:copy p2))))))))
   (compute-polyhedron-data mesh))
@@ -326,4 +326,3 @@
  "Create" :u "Create UV Mesh Menu"
  (lambda () (make-active-command-table (uv-mesh-command-table)))
  (lambda () t))
-

--- a/test/demo-object-picking.lisp
+++ b/test/demo-object-picking.lisp
@@ -131,3 +131,51 @@ Make sure you have opened the graphics window by doing:
 ;;; 2. `picking-selector-click-multi` - This selector function comes into effect
 ;;; when a left click occurs while the shift key was pressed down. The behaviour
 ;;; is to `add` to the current selection, the closest unselected object.
+
+
+;;; Point picking. Now lets take an action when individual points are selected.
+;;; First enable point picking mode and then register a picking selector that
+;;; can ehandle selected points.
+(setf *point-picking-enabled* t)
+
+;; This picking selector will ignore selected objects effectively disabling
+;; shape selection. It is possible to retain the behaviour of both selecting
+;; objects and picking points.
+
+(let ((selector nil))
+  (setf *picking-selector*
+	(lambda (&key xs-hit xs-miss xs-current xs-point)
+	  (declare (ignore xs-hit xs-miss xs-current))
+	  (if xs-point
+	      ;; When a point is selected draw a small red sphere at that point
+	      (progn
+		(when selector (remove-shape *scene* selector))
+		(setf selector (translate-to (make-cube-sphere 0.2 2) (first xs-point)))
+		(set-point-colors-uniform selector (c! 1.0 0.0 0.0))
+		(add-shape *scene* selector))
+	      ;; Otherwise if we select nothing remove the red sphere selector
+	      (when selector (remove-shape *scene* selector))))))
+
+
+(with-clear-scene
+  (flet ((random-shape (size)
+           (funcall
+            (elt '(make-cube make-octahedron make-icosahedron) (random 3))
+            size)))
+    (let ((step 1) (shape-size 0.4) (bound 1))
+      (do ((x (- bound) (+ x step)))
+          ((> x bound))
+        (do ((y (- bound) (+ y step)))
+            ((> y bound))
+          (do ((z (- bound) (+ z step)))
+              ((> z bound))
+            (add-shape (scene *scene-view*)
+                       (translate-to (random-shape shape-size) (p! x y z)))))))))
+
+
+;; Use the same point picking selector function above and now try selecting points on this
+;; rectangle. Point picking works with curves.
+(progn
+  (defparameter *rectangle* (make-rectangle 4.0 2.0 2))
+  (with-clear-scene
+    (add-shape *scene* *rectangle*)))


### PR DESCRIPTION
Hello @kaveh808 and thanks for the kons-9 project. I'm building a wavetable synth editor, so basically 3D height-field transformations that will be used in audio oscillators. As part of the editor I want dynamic mouse-driven point-and-click editing such as increasing height and decreasing height when mouse is clicked. Similar to the terrain builder mechanics in simulation games. 

To accomplish this with kons-9 I have added point selection within the current shape selection machinery. Now, a custom selection handler can trigger an action like transforming the region around the selected point. I have provided a simple example that draws a sphere at the closest clicked point.

The code adds a very small fixed cost to object selection, most of the calculations for finding the closest vertex to the ray or cone was already there. Only a few basic vec operations to get the closest vertex point were necessary.

I've made the changes in a backwards compatible way. If `*point-picking-enabled*` is not set to `t` then the selection handlers are called with the previous keyword arguments. If it set to `t` however, the selection handler is expected to contain an additional keyword argument for `xs-point` (which is a list of the closest picked vertex for the list of selected shapes).